### PR TITLE
fix: broken scroll position after changing inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+## @exodus/react-native-keyboard-aware-scroll-view
+
+Keyboard aware scrollview with scroll position bug fixed
+
+
 # react-native-keyboard-aware-scroll-view
 
 <p>

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -361,6 +361,7 @@ function KeyboardAwareHOC(
 
     // Keyboard actions
     _updateKeyboardSpace = (frames: Object) => {
+      this.defaultResetScrollToCoords = null
       // Automatically scroll to focused TextInput
       if (this.props.enableAutomaticScroll) {
         let keyboardSpace: number =

--- a/lib/KeyboardAwareHOC.js
+++ b/lib/KeyboardAwareHOC.js
@@ -361,7 +361,6 @@ function KeyboardAwareHOC(
 
     // Keyboard actions
     _updateKeyboardSpace = (frames: Object) => {
-      this.defaultResetScrollToCoords = null
       // Automatically scroll to focused TextInput
       if (this.props.enableAutomaticScroll) {
         let keyboardSpace: number =
@@ -439,6 +438,13 @@ function KeyboardAwareHOC(
       this.setState({ keyboardSpace })
       // Reset scroll position after keyboard dismissal
       if (this.props.enableResetScrollToCoords === false) {
+        if(this.position.y > this._maxScrollOffset){
+          this.scrollToPosition(
+            0,
+            this._maxScrollOffset,
+            true
+          )
+        }
         this.defaultResetScrollToCoords = null
         return
       } else if (this.props.resetScrollToCoords) {
@@ -503,6 +509,24 @@ function KeyboardAwareHOC(
       this._scrollToFocusedInputWithNodeHandle(currentlyFocusedField)
     }
 
+    _calculateMaxScrollOffset = () =>{
+      if(this._contentHeight && this._viewHeight && !this._maxScrollOffset){
+        this._maxScrollOffset = this._contentHeight - this._viewHeight
+      }
+    }
+
+    _onLayout = (event) =>{
+      this.props.onLayout?.(event)
+      this._viewHeight = event.nativeEvent.layout.height
+      this._calculateMaxScrollOffset()
+    }
+
+    _onContentSizeChange = (contentWidth, contentHeight) => {
+      this.props.onContentSizeChange?.(contentWidth, contentHeight)
+      this._contentHeight = contentHeight
+      this._calculateMaxScrollOffset()
+    }
+
     render() {
       const { enableOnAndroid, contentContainerStyle, onScroll } = this.props
       let newContentContainerStyle
@@ -537,6 +561,8 @@ function KeyboardAwareHOC(
           handleOnScroll={this._handleOnScroll}
           update={this.update}
           onScroll={Animated.forkEvent(onScroll, this._handleOnScroll)}
+          onContentSizeChange={this._onContentSizeChange}
+          onLayout={this._onLayout}
         />
       )
     }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/APSL/react-native-keyboard-aware-scroll-view.git"
+    "url": "git+https://github.com/ExodusMovement/react-native-keyboard-aware-scroll-view.git"
   },
   "files": [
     "index.js",
@@ -37,9 +37,9 @@
   "author": "Alvaro Medina Ballester <me@alvaromb.com>",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/APSL/react-native-keyboard-aware-scroll-view/issues"
+    "url": "https://github.com/ExodusMovement/react-native-keyboard-aware-scroll-view/issues"
   },
-  "homepage": "https://github.com/APSL/react-native-keyboard-aware-scroll-view#readme",
+  "homepage": "https://github.com/ExodusMovement/react-native-keyboard-aware-scroll-view#readme",
   "dependencies": {
     "prop-types": "^15.6.2",
     "react-native-iphone-x-helper": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
   "bugs": {
     "url": "https://github.com/ExodusMovement/react-native-keyboard-aware-scroll-view/issues"
   },
-  "homepage": "https://github.com/ExodusMovement/react-native-keyboard-aware-scroll-view#readme",
+  "homepage": "https://github.com/APSL/react-native-keyboard-aware-scroll-view#readme",
   "dependencies": {
     "prop-types": "^15.6.2",
     "react-native-iphone-x-helper": "^1.0.3"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "react-native-keyboard-aware-scroll-view",
-  "version": "0.9.1",
+  "name": "@exodus/react-native-keyboard-aware-scroll-view",
+  "version": "0.9.1-exodus.1",
   "description": "A React Native ScrollView component that resizes when the keyboard appears.",
   "main": "index.js",
   "types": "index.d.ts",
@@ -13,6 +13,11 @@
     "type": "git",
     "url": "git+https://github.com/APSL/react-native-keyboard-aware-scroll-view.git"
   },
+  "files": [
+    "index.js",
+    "index.d.ts",
+    "lib/*.js"
+  ],
   "tags": [
     "react",
     "react-native",


### PR DESCRIPTION
Fixes: https://github.com/APSL/react-native-keyboard-aware-scroll-view/issues/313
ATM enableResetScrollToCoords need to be false 

without this fix:

https://user-images.githubusercontent.com/5978212/145774662-a907272d-ecbf-40e1-b658-d3d9e24c3a97.mp4

With fix:

https://user-images.githubusercontent.com/5978212/145774678-8d28fbcb-d937-4e55-bc4d-a51e04c27a5b.mp4
